### PR TITLE
Set api_key to default empty string to prevent error

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -30,7 +30,7 @@ class Config
         return $this->scopeConfig->getValue(
             self::API_KEY_CONFIG_PATH,
             ScopeInterface::SCOPE_STORE
-        );
+        ) ?? '';
     }
 
     public function slugPrefix(): string

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "medialounge/magento2-storyblok-integration",
     "description": "Magento 2 extension to integrate Storyblok visual editor",
     "type": "magento2-module",
-    "version": "3.0.6",
+    "version": "3.0.7",
     "license": "GPL-3.0-only",
     "authors": [
         {


### PR DESCRIPTION
If the storyblok functionality is turned off and no api_key is set, PHP is throwing a: "Argument #1 ($apiKey) must be of type string, null given" error.

To prevent this error, a default empty string is returned.